### PR TITLE
Restyling, landing page, and login/signup text

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -108,28 +108,22 @@ body {
   justify-content: space-between;
   align-items: center;
   text-align: center;
-  background: white;
-  padding: 5px 10%;
+  background-color: blue;
+  padding: 10px 25px;
   -webkit-box-shadow: 0 8px 6px -6px #999;
   -moz-box-shadow: 0 8px 6px -6px #999;
   box-shadow: 0 8px 6px -6px #999;
 }
 
-@media only screen and (max-width: 630px) {
-  .nav {
-    justify-content: flex-start;
-  }
-}
-
 .inactive {
   margin: 0 5px;
-  color: blue;
+  color: white;
   text-decoration: none;
 }
 
 .active-link {
   margin: 0 5px;
-  color: darkblue;
+  text-decoration: underline;
 }
 
 @media only screen and (max-width: 390px) {
@@ -152,12 +146,6 @@ body {
   font-family: 'Saira';
   color: #003893;
   font-weight: 900;
-}
-
-@media only screen and (max-width: 630px) {
-  .logo {
-    display: none;
-  }
 }
 
 /* Header styles */

--- a/src/components/GqlQueries/logQueries.js
+++ b/src/components/GqlQueries/logQueries.js
@@ -94,4 +94,4 @@ const MY_LOGS_BY_DATE = gql`
   }
 `;
 
-export { LOGS, CREATE_LOG, MY_LOGS_BY_DATE };
+export { LOGS, CREATE_LOG, MY_LOGS_BY_DATE, MY_LOGS };

--- a/src/components/Landing/index.js
+++ b/src/components/Landing/index.js
@@ -1,146 +1,43 @@
 import React, { useState, useEffect } from 'react';
-import { useQuery } from 'react-apollo-hooks';
-import gql from 'graphql-tag';
-import Info from '../Verb/Info';
-import Input from '../Verb/Input';
+import { withStyles } from '@material-ui/core/styles';
+import Container from '../Verb/Container';
+import Signup from '../Signup';
 
-const LEVEL_ONE = gql`
-  query {
-    verbs(
-      where: {
-        AND: [{ moodEnglish: "Indicative" }, { tenseEnglish: "Present" }]
-        OR: [
-          { infinitive: "caminar" }
-          { infinitive: "hablar" }
-          { infinitive: "ayudar" }
-          { infinitive: "necesitar" }
-          { infinitive: "escribir" }
-          { infinitive: "esperar" }
-          { infinitive: "cocinar" }
-          { infinitive: "comer" }
-          { infinitive: "beber" }
-          { infinitive: "vivir" }
-        ]
-      }
-    ) {
-      form1p
-      form1s
-      form2s
-      form3p
-      form3s
-      infinitive
-      infinitiveEnglish
-      moodEnglish
-      tenseEnglish
-      verbEnglish
-    }
-  }
-`;
+const styles = theme => ({
+  main: {
+    width: '100%',
+    margin: '10px auto',
+    [theme.breakpoints.up('sm')]: {
+      width: '580px',
+    },
+  },
+})
 
-function Landing() {
-  const [value, setValue] = useState('');
-
-  const [answer, setAnswer] = useState({
-    answered: false,
-    correct: false,
-    helperText: '',
-  });
-
-  const [verb, setVerb] = useState({
-    infinitive: '',
-    tenseEnglish: '',
-    infinitiveEnglish: '',
-    moodEnglish: '',
-    answer: '',
-    person: '',
-  });
-
-  const buttonText =
-    verb.answer !== value.toLowerCase() && answer.answered
-      ? 'Next verb'
-      : 'Submit';
-
-  const { loading, data } = useQuery(LEVEL_ONE);
-
-  const getRandomVerb = () => {
-    // this checks to see if the gql query has loaded
-    if (Object.values(data).length !== 0) {
-      const dataLength = Object.keys(data.verbs).length;
-      const randomNum = Math.floor(Math.random() * dataLength);
-      const randomVerbNum = Math.floor(Math.random() * 5); // this grabs the 6 yo, tu, ellos etc that we want to use
-      const randomVerb = data.verbs[randomNum];
-
-      setVerb({
-        infinitive: randomVerb.infinitive,
-        infinitiveEnglish: randomVerb.infinitiveEnglish,
-        tenseEnglish: randomVerb.tenseEnglish,
-        moodEnglish: randomVerb.moodEnglish,
-        person: Object.keys(randomVerb)[randomVerbNum],
-        answer: Object.values(randomVerb)[randomVerbNum],
-      });
-    }
-  };
-
-  useEffect(() => {
-    getRandomVerb();
-  }, [data]);
-
-  const addAccent = event => {
-    event.preventDefault();
-    const accent = event.target.value;
-    setValue(value + accent);
-  };
-
-  const handleRefresh = () => {
-    getRandomVerb();
-    setValue('');
-    setAnswer({
-      answered: false,
-      correct: false,
-      helperText: '',
-    });
-  };
-
-  const handleSubmit = async event => {
-    event.preventDefault();
-    const userInput = value.toLowerCase();
-    if (answer.answered) {
-      handleRefresh();
-    }
-    // if the answer is correct
-    else if (userInput === verb.answer) {
-      setAnswer({
-        correct: true,
-        answered: true,
-      });
-    } // if the answer is incorrect
-    else if (userInput !== verb.answer) {
-      setAnswer({
-        correct: false,
-        answered: true,
-        helperText: `False, the correct answer is ${verb.answer.toUpperCase()}.`,
-      });
-    }
-  };
-
+function Landing(props) {
+  const { classes } = props;
   return (
     <div>
-      <h1 style={{ textAlign: 'center' }}>
-        Easy verb practice for Spanish language learners.
-      </h1>
-      <Info verb={verb} loading={loading} />
-      <Input
-        helperText={answer.helperText}
-        correct={answer.correct}
-        value={value}
-        buttonText={buttonText}
-        addAccent={addAccent}
-        handleSubmit={handleSubmit}
-        person={verb.person}
-        setValue={setValue}
-      />
+      <div style={{ textAlign: 'center' }}>
+        <h1 className="logo">Bienvenido al Spanish Conjugator{' '}
+          <span role="img" aria-label="colombia">
+            🇪🇸
+          </span>
+        </h1>
+        <h2>Verb practice made easy.</h2>
+      </div>
+      <Container />
+      <div className={classes.main} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+        <h2>Sign up now to level up your language learning.</h2>
+        <img style={{ maxHeight: '487px', maxWidth: '684px' }} src="https://media.giphy.com/media/QsPVRVxhjQjshpu3Uj/giphy.gif" />
+        <h2>Collect your stats</h2>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. In viverra suscipit odio at cursus. Nunc vitae leo consequat, gravida ex nec, pulvinar augue. Phasellus vestibulum nunc erat, vitae mattis odio congue vel. Nulla congue felis est, et vulputate orci iaculis vitae.</p>
+        <img style={{ maxHeight: '487px', maxWidth: '684px' }} src="https://media.giphy.com/media/ZatvyBr6G2kQQjN64D/giphy.gif" />
+        <h2>Take your skills to the next level</h2>
+         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. In viverra suscipit odio at cursus. Nunc vitae leo consequat, gravida ex nec, pulvinar augue. Phasellus vestibulum nunc erat, vitae mattis odio congue vel. Nulla congue felis est, et vulputate orci iaculis vitae.</p>
+      </div>
+      <Signup />
     </div>
   );
 }
 
-export default Landing;
+export default withStyles(styles)(Landing);

--- a/src/components/Layout/Header.js
+++ b/src/components/Layout/Header.js
@@ -3,14 +3,14 @@ import React from 'react';
 function Header() {
   return (
     <div className="header">
-      <h2>
+      <h1>
         <span className="logo">
-          Bienvenido al Spanish Conjugator{' '}
+          Conjugator{' '}
           <span role="img" aria-label="colombia">
             🇪🇸
           </span>
         </span>
-      </h2>
+      </h1>
     </div>
   );
 }

--- a/src/components/Layout/Nav.js
+++ b/src/components/Layout/Nav.js
@@ -4,18 +4,13 @@ import { NavLink } from 'react-router-dom';
 function Nav(props) {
   return (
     <nav className="nav">
-      <NavLink className="inactive" to="/">
-        <span className="logo">Spanish Conjugator</span>
+      <NavLink
+        className="inactive"
+        to="/"
+      >
+        Spanish Conjugator
       </NavLink>
       <div>
-        <NavLink
-          exact
-          activeClassName="active-link"
-          className="inactive"
-          to="/"
-        >
-          Home
-        </NavLink>
         <NavLink
           exact
           activeClassName="active-link"

--- a/src/components/Login/index.js
+++ b/src/components/Login/index.js
@@ -92,7 +92,7 @@ function Login(props) {
             <button type="submit">Login</button>
           </Button>
         <p className={classes.text}>
-          Already have an account? <Link to="/signup">Sign up here</Link>
+          Don't have an account yet? <Link to="/signup" style={{ color: 'blue' }}>Sign up here</Link>
         </p>
         </form>
       </Paper>

--- a/src/components/Login/index.js
+++ b/src/components/Login/index.js
@@ -1,11 +1,30 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { SmallForm } from '../../styled/Form';
-import { LargeContainer } from '../../styled/Container';
-import { Input } from '../../styled/Input';
+import { withStyles } from '@material-ui/core/styles';
+import Paper from '@material-ui/core/Paper';
+import FormGroup from '@material-ui/core/FormGroup';
+import TextField from '@material-ui/core/TextField';
 import { Button } from '../../styled/Button';
 import { LOGIN } from '../GqlQueries/userQueries';
 import { useMutation } from 'react-apollo-hooks';
+
+const styles = theme => ({
+  main: {
+    width: '100%',
+    margin: '10px auto',
+    backgroundColor: '#fafafa',
+    [theme.breakpoints.up('sm')]: {
+      width: '580px',
+    },
+  },
+  input: {
+    padding: '15px 30px',
+  },
+  text: {
+    textAlign: 'center',
+    padding: '15px 0',
+  }
+})
 
 function Login(props) {
   const [email, setEmail] = useState('');
@@ -39,36 +58,46 @@ function Login(props) {
     }
   };
 
+  const { classes } = props
+
   return (
-    <SmallForm onSubmit={handleSubmit}>
-      <h2>Login</h2>
-      <LargeContainer>
-        <Input>
-          <input
-            type="email"
-            value={email}
-            placeholder="Email"
-            onChange={e => setEmail(e.target.value)}
-            name="email"
-          />
-          <input
-            type="password"
-            value={password}
-            placeholder="Password"
-            onChange={e => setPassword(e.target.value)}
-            name="password"
-          />
-          {error ? <div>Unable to login</div> : null}
+    <div>
+      <div style={{ textAlign: 'center' }}>
+        <h1 className="logo">Login</h1>
+      </div>
+      <Paper className={classes.main} elevation={10}>
+        <form onSubmit={handleSubmit}>
+          <FormGroup>
+            <TextField
+              className={classes.input}
+              type="email"
+              value={email}
+              placeholder="Email"
+              onChange={e => setEmail(e.target.value)}
+              name="email"
+            />
+          </FormGroup>
+          <FormGroup>
+            <TextField
+              className={classes.input}
+              type="password"
+              value={password}
+              placeholder="Password"
+              onChange={e => setPassword(e.target.value)}
+              name="password"
+            />
+          </FormGroup>
+          {error ? <div className={classes.text}>Unable to login</div> : null}
           <Button>
             <button type="submit">Login</button>
           </Button>
-        </Input>
-        <p>
+        <p className={classes.text}>
           Already have an account? <Link to="/signup">Sign up here</Link>
         </p>
-      </LargeContainer>
-    </SmallForm>
+        </form>
+      </Paper>
+    </div>
   );
 }
 
-export default Login;
+export default withStyles(styles)(Login);

--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -1,9 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import Typography from '@material-ui/core/Typography';
 import Paper from '@material-ui/core/Paper';
-import AppBar from '@material-ui/core/AppBar';
-import Toolbar from '@material-ui/core/Toolbar';
 import { withStyles } from '@material-ui/core/styles';
 import Latam from './Latam';
 import Difficulty from './Difficulty';
@@ -46,15 +43,12 @@ function Settings(props) {
     }, 1000);
   };
 
-  // console.log('classes from advSettings', props);
   return (
     <div>
+      <div style={{ textAlign: 'center' }}>
+        <h1 className="logo">Settings</h1>
+      </div>
       <Paper className={classes.main} elevation={10}>
-        {/* <AppBar color="primary" position="static" style={{ height: '64px' }}>
-          <Toolbar>
-            <Typography color="inherit">Select your settings</Typography>
-          </Toolbar>
-        </AppBar> */}
         <Latam />
         <Difficulty />
         <Tenses />

--- a/src/components/Settings/Tenses.js
+++ b/src/components/Settings/Tenses.js
@@ -35,9 +35,7 @@ function Tenses(props) {
     setPresent,
     pret,
     setPret,
-    tenseArr,
     useUpdate,
-    subjArr,
     useSubjChange
   } = useContext(SettingsContext);
 

--- a/src/components/Signup/index.js
+++ b/src/components/Signup/index.js
@@ -1,11 +1,30 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
+import { withStyles } from '@material-ui/core/styles';
+import Paper from '@material-ui/core/Paper';
+import FormGroup from '@material-ui/core/FormGroup';
+import TextField from '@material-ui/core/TextField';
 import { Button } from '../../styled/Button';
-import { SmallForm } from '../../styled/Form';
-import { LargeContainer } from '../../styled/Container';
-import { Input } from '../../styled/Input';
 import { useMutation } from 'react-apollo-hooks';
 import { CREATE_USER } from '../GqlQueries/userQueries';
+
+const styles = theme => ({
+  main: {
+    width: '100%',
+    margin: '10px auto',
+    backgroundColor: '#fafafa',
+    [theme.breakpoints.up('sm')]: {
+      width: '580px',
+    },
+  },
+  input: {
+    padding: '15px 30px',
+  },
+  text: {
+    textAlign: 'center',
+    padding: '15px 0',
+  }
+})
 
 function Signup(props) {
   const [name, setName] = useState('');
@@ -40,43 +59,56 @@ function Signup(props) {
     }
   };
 
+  const { classes } = props
+
   return (
-    <SmallForm onSubmit={handleSubmit}>
-      <h2>Sign up</h2>
-      <LargeContainer>
-        <Input>
-          <input
-            type="name"
-            value={name}
-            placeholder="Name"
-            onChange={e => setName(e.target.value)}
-            name="name"
-          />
-          <input
-            type="email"
-            value={email}
-            placeholder="Email"
-            onChange={e => setEmail(e.target.value)}
-            name="email"
-          />
-          <input
-            type="password"
-            value={password}
-            placeholder="Password"
-            onChange={e => setPassword(e.target.value)}
-            name="password"
-          />
-        </Input>
-        {error ? <p>Password needs to be at least 8 characters</p> : null}
-        <Button>
-          <button type="submit">Sign up</button>
-        </Button>
-        <p>
-          Don't have an account yet? <Link to="/login">Log in here</Link>
-        </p>
-      </LargeContainer>
-    </SmallForm>
+    <div>
+      <div style={{ textAlign: 'center' }}>
+        <h1 className="logo">Sign up</h1>
+      </div>
+      <Paper className={classes.main} elevation={10}>
+        <form onSubmit={handleSubmit}>
+          <FormGroup>
+            <TextField
+              className={classes.input}
+              type="name"
+              value={name}
+              placeholder="Name"
+              onChange={e => setName(e.target.value)}
+              name="name"
+            />
+          </FormGroup>
+          <FormGroup>
+            <TextField
+              className={classes.input}
+              type="email"
+              value={email}
+              placeholder="Email"
+              onChange={e => setEmail(e.target.value)}
+              name="email"
+            />
+          </FormGroup>
+          <FormGroup>
+            <TextField
+              className={classes.input}
+              type="password"
+              value={password}
+              placeholder="Password"
+              onChange={e => setPassword(e.target.value)}
+              name="password"
+            />
+          </FormGroup>
+          {error ? <p className={classes.text}>Password needs to be at least 8 characters</p> : null}
+          <Button>
+            <button type="submit">Sign up</button>
+          </Button>
+          <p className={classes.text}>
+            Don't have an account yet? <Link to="/login">Log in here</Link>
+          </p>
+        </form>
+      </Paper>
+    </div>
   );
 }
 
-export default Signup;
+export default withStyles(styles)(Signup);

--- a/src/components/Signup/index.js
+++ b/src/components/Signup/index.js
@@ -103,7 +103,7 @@ function Signup(props) {
             <button type="submit">Sign up</button>
           </Button>
           <p className={classes.text}>
-            Don't have an account yet? <Link to="/login">Log in here</Link>
+            Already have an account? <Link to="/login" style={{ color: 'blue' }}>Log in here</Link>
           </p>
         </form>
       </Paper>

--- a/src/components/Verb/Container.js
+++ b/src/components/Verb/Container.js
@@ -7,7 +7,6 @@ import Input from './Input';
 import { verbQueries } from '../GqlQueries/verbQueries';
 import { CREATE_LOG } from '../GqlQueries/logQueries';
 import Stats from './Stats';
-import Header from '../Layout/Header';
 
 function Container() {
   const [value, setValue] = useState('');
@@ -152,8 +151,14 @@ function Container() {
 
   return (
     <div className="app">
-      <Header />
-      <Stats count={count} percentage={percentage} bestStreak={bestStreak} />
+      <div style={{ textAlign: 'center' }}>
+        <h1 className="logo"><span>
+          Conjugator{' '}
+          <span role="img" aria-label="colombia">
+            🇪🇸
+          </span>
+        </span> </h1>
+      </div>
       <div
         style={{
           borderRadius: '4px',
@@ -163,6 +168,7 @@ function Container() {
           padding: '10px',
         }}
       >
+        <Stats count={count} percentage={percentage} bestStreak={bestStreak} />
         <Info verb={verb} loading={loading} />
         <Input
           helperText={helperText}

--- a/src/components/Verb/Container.js
+++ b/src/components/Verb/Container.js
@@ -166,14 +166,17 @@ function Container(props) {
 
   return (
     <div>
-      <div style={{ textAlign: 'center' }}>
-        <h1 className="logo"><span>
-          Conjugator{' '}
-          <span role="img" aria-label="colombia">
-            🇪🇸
-          </span>
-        </span> </h1>
-      </div>
+      {
+        !window.location.href.match(/landing/) &&
+        <div style={{ textAlign: 'center' }}>
+          <h1 className="logo"><span>
+            Conjugator{' '}
+            <span role="img" aria-label="colombia">
+              🇪🇸
+            </span>
+          </span> </h1>
+        </div>
+      }
       <Paper className={classes.main} elevation={10}>
         <Stats count={count} percentage={percentage} bestStreak={bestStreak} />
         <Info verb={verb} loading={loading} />

--- a/src/components/Verb/Container.js
+++ b/src/components/Verb/Container.js
@@ -1,5 +1,7 @@
 import React, { useState, useEffect, useContext } from 'react';
 import PropTypes from 'prop-types';
+import { withStyles } from '@material-ui/core/styles';
+import Paper from '@material-ui/core/Paper';
 import { useQuery, useMutation } from 'react-apollo-hooks';
 import { SettingsContext } from '../Contexts/SettingsContext';
 import Info from './Info';
@@ -8,7 +10,18 @@ import { verbQueries } from '../GqlQueries/verbQueries';
 import { CREATE_LOG } from '../GqlQueries/logQueries';
 import Stats from './Stats';
 
-function Container() {
+const styles = theme => ({
+  main: {
+    width: '100%',
+    margin: '10px auto',
+    backgroundColor: '#fafafa',
+    [theme.breakpoints.up('sm')]: {
+      width: '580px',
+    },
+  },
+})
+
+function Container(props) {
   const [value, setValue] = useState('');
   const [bestStreak, setBestStreak] = useState(0);
   const [totalAnswers, setTotalAnswers] = useState(0);
@@ -149,8 +162,10 @@ function Container() {
     );
   };
 
+  const { classes } = props;
+
   return (
-    <div className="app">
+    <div>
       <div style={{ textAlign: 'center' }}>
         <h1 className="logo"><span>
           Conjugator{' '}
@@ -159,15 +174,7 @@ function Container() {
           </span>
         </span> </h1>
       </div>
-      <div
-        style={{
-          borderRadius: '4px',
-          boxShadow:
-            '0px 6px 6px -3px rgba(0, 0, 0, 0.2), 0px 10px 14px 1px rgba(0, 0, 0, 0.14), 0px 4px 18px 3px rgba(0, 0, 0, 0.12)',
-          backgroundColor: 'white',
-          padding: '10px',
-        }}
-      >
+      <Paper className={classes.main} elevation={10}>
         <Stats count={count} percentage={percentage} bestStreak={bestStreak} />
         <Info verb={verb} loading={loading} />
         <Input
@@ -181,7 +188,7 @@ function Container() {
           setValue={setValue}
           handleExample={handleExample}
         />
-      </div>
+      </Paper>
     </div>
   );
 }
@@ -193,4 +200,4 @@ Container.propTypes = {
   updateLatam: PropTypes.func,
 };
 
-export default Container;
+export default withStyles(styles)(Container);

--- a/src/components/Verb/Input.js
+++ b/src/components/Verb/Input.js
@@ -19,7 +19,7 @@ function Input(props) {
   } = props;
 
   return (
-    <div>
+    <div style={{ padding: "15px 20px"}}>
       <form onSubmit={handleSubmit}>
         <div className="input-section">
           <Person person={person} />

--- a/src/components/Verb/Stats.js
+++ b/src/components/Verb/Stats.js
@@ -23,7 +23,7 @@ function Stats(props) {
 
 Stats.propTypes = {
   count: PropTypes.number,
-  percentage: PropTypes.number,
+  percentage: PropTypes.string,
   bestStreak: PropTypes.number,
 };
 

--- a/src/styled/Input.js
+++ b/src/styled/Input.js
@@ -11,7 +11,6 @@ export const Input = styled.div`
     font-size: 1.2rem;
     border: none;
     border-bottom: solid 2px #003893;
-    background-color: white;
     height: 35px;
     margin: 10px 0;
     padding: 0 10px;


### PR DESCRIPTION
You'll notice each page has consistent styling with a `Paper` wrapper around the main component
The nav now has a blue background and white text with underline when active
There is a basic landing page at `/landing` - I think we should make this the new unauthenticated homepage
`Already have an account? Log in here` and `Don't have an account yet? Sign up here` were switched.